### PR TITLE
Implement RSS feeds for podcasts and meditation categories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
     "rules": {
         "no-underscore-dangle": [ "error", { "allowAfterThis": true } ],
         "import/prefer-default-export": [ "off" ],
+        "prefer-destructuring": [ "off " ],
     }
 };

--- a/aws/deploy_policy.json
+++ b/aws/deploy_policy.json
@@ -67,6 +67,7 @@
         "cloudformation:Describe*",
         "cloudformation:List*",
         "cloudformation:Get*",
+        "cloudformation:SetStackPolicy",
         "cloudformation:PreviewStackUpdate",
         "cloudformation:CreateStack",
         "cloudformation:UpdateStack",
@@ -194,6 +195,13 @@
       "Action": [
         "cloudwatch:*",
         "events:*"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "dynamodb:*Table*"
       ],
       "Resource": "*",
       "Effect": "Allow"

--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@ async function getPledge(patreon) {
 }
 
 function filterEntry(entry, pledge, podcasts) {
-  console.log(entry, podcasts);
   if (canAccess(pledge, entry, podcasts)) {
     return _.set(entry, 'fields.patronsOnly', false);
   }
@@ -180,7 +179,6 @@ function handleLiturgistsToken() {
           // Assign token mapping and pledge to request object for later use
           req.tokenMapping = items[0].attrs;
           req.pledge = await getPledge({ token: patreonToken, campaignUrl });
-          console.log('pledge:', req.pledge);
         } catch (err) {
           console.error(err);
           res.status(401).json({ error: 'invalid token' });
@@ -269,8 +267,6 @@ async function init() {
           .exec()
           .promise();
 
-        console.log('TokenMapping resp:', resp);
-
         const [{ Items: items }] = resp;
         console.log(`Destroying ${items.length} existing patreon records`);
         await Promise.all(items.map(item => item.destroy()));
@@ -302,7 +298,6 @@ async function init() {
       async (req, res) => {
         const path = req.params[1];  // second wildcard match
         const url = `${patreonApiUrl}/api/${path}`;
-        console.log('tokenMapping:', req.tokenMapping);
         const token = req.tokenMapping.patreonToken;
         const patreonRes = await axios.get(
           url,
@@ -313,7 +308,6 @@ async function init() {
             },
           }
         );
-        console.log('patreon response', patreonRes);
         res.status(patreonRes.status).json(patreonRes.data);
       },
     ),
@@ -563,7 +557,6 @@ async function init() {
           ],
         });
 
-        // TODO: handle contentful pagination
         items.forEach((entry) => {
           feed.item({
             guid: entry.sys.id,

--- a/index.js
+++ b/index.js
@@ -196,6 +196,16 @@ async function refreshPatreonToken(tokenMapping) {
 function handleLiturgistsToken() {
   return wrapAsync(
     async (req, res, next) => {
+      const ERROR_CODE_NEED_PATREON_REAUTH = 'needPatreonReauth';
+      if (_.has(req.headers, 'x-theliturgists-patreon-token')) {
+        // old version of the app; needs patreon re-auth
+        res.status(401).json({
+          error: 'invalid auth header',
+          code: ERROR_CODE_NEED_PATREON_REAUTH,
+        });
+        return;
+      }
+
       const token = _.get(
         req.headers,
         'x-theliturgists-token',
@@ -247,7 +257,10 @@ function handleLiturgistsToken() {
             );
             await tokenMappingObj.destroy();
           }
-          res.status(401).json({ error: 'invalid token' });
+          res.status(401).json({
+            error: 'invalid token',
+            code: ERROR_CODE_NEED_PATREON_REAUTH,
+          });
           return;
         }
       }

--- a/index.js
+++ b/index.js
@@ -337,6 +337,11 @@ async function init() {
         res.status(401).send('feed access denied');
         return;
       }
+      if (collectionObj.fields.feedUrl) {
+        res.redirect(collectionObj.fields.feedUrl);
+        return;
+      }
+
       if (collectionObj.fields.image) {
         const assetId = collectionObj.fields.image.sys.id;
         const imageAsset = await contentfulGet(`assets/${assetId}`, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,34 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/hoek": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.1.tgz",
+      "integrity": "sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA=="
+    },
+    "@hapi/joi": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
+      "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
+      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      }
+    },
     "@sentry/core": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.6.4.tgz",
@@ -226,6 +254,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "archiver": {
       "version": "1.3.0",
@@ -575,6 +608,11 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -590,6 +628,16 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
+    },
+    "bunyan": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.5.1.tgz",
+      "integrity": "sha1-X259RMQ7lS9WsPQTCeOrEjkbTi0=",
+      "requires": {
+        "dtrace-provider": "~0.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -1201,10 +1249,72 @@
         "pify": "^2.3.0"
       }
     },
+    "dtrace-provider": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+      "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.0.8"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
+    "dynamodb": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dynamodb/-/dynamodb-1.2.0.tgz",
+      "integrity": "sha512-O28acIHevSLRL7GOzX2oKgPD2tQnzjJsy92L27hjUGUXz+ETgLRTVw5lOujIIpLJBncDNJlx1KN1qfBwp2AmMw==",
+      "requires": {
+        "async": "1.5.x",
+        "aws-sdk": "^2.186.x",
+        "bunyan": "1.5.x",
+        "joi": "10.6.x",
+        "lodash": "4.x.x",
+        "node-uuid": "1.4.x",
+        "stream-to-promise": "~2.2.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+        },
+        "joi": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "requires": {
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
+          }
+        },
+        "topo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2658,6 +2768,11 @@
         "is-object": "^1.0.1"
       }
     },
+    "items": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -2734,6 +2849,23 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "jszip": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
@@ -2743,6 +2875,25 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "jwt-decode": {
@@ -2836,6 +2987,41 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -3052,6 +3238,47 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
+    "nan": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -3081,6 +3308,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -3104,6 +3337,11 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-package-data": {
       "version": "2.4.2",
@@ -3876,6 +4114,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -4069,6 +4313,11 @@
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
@@ -4417,6 +4666,42 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "stream-to-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+      "integrity": "sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=",
+      "requires": {
+        "any-promise": "~1.3.0",
+        "end-of-stream": "~1.1.0",
+        "stream-to-array": "~2.3.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+          "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+          "requires": {
+            "once": "~1.3.0"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -4885,9 +5170,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4476,6 +4476,11 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,11 +244,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.11"
           }
         }
       }
@@ -446,9 +446,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -611,6 +611,11 @@
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       }
+    },
+    "cachedir": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
+      "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ=="
     },
     "callsites": {
       "version": "3.0.0",
@@ -844,9 +849,9 @@
       }
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compress-commons": {
       "version": "1.2.2",
@@ -2313,9 +2318,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ienoopen": {
       "version": "1.0.0",
@@ -2327,6 +2332,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -2660,9 +2670,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2688,9 +2698,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
         }
       }
     },
@@ -2722,6 +2732,17 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "jszip": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
+      "integrity": "sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       }
     },
     "jwt-decode": {
@@ -2774,6 +2795,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "load-json-file": {
@@ -3398,6 +3427,11 @@
         "semver": "^5.1.0"
       }
     },
+    "pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+    },
     "parent-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
@@ -3447,9 +3481,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-loader": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.9.tgz",
-      "integrity": "sha512-pD37gArtr+/72Tst9oJoDB9k7gB9A09Efj7yyBi5HDUqaxqULXBWW8Rnw2TfNF+3sN7QZv0ZNdW1Qx2pFGW5Jg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.10.tgz",
+      "integrity": "sha512-CMP0v6S6z8PHeJ6NFVyVJm6WyJjIwFvyz2b0n2/4bKdS/0uZa/9sKUlYZzubrn3zuDRU0zIuEDX9DZYQ2ZI8TA==",
       "requires": {
         "native-promise-only": "^0.8.1",
         "superagent": "^3.8.3"
@@ -3704,9 +3738,9 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -3780,6 +3814,30 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
       }
     },
     "rss-parser": {
@@ -3914,14 +3972,15 @@
       }
     },
     "serverless": {
-      "version": "1.36.3",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.36.3.tgz",
-      "integrity": "sha512-tFiePa29gHrbG3EbmegVeScUsJrDP+sB93nGPNW/R6DGccqxcI+84zZ2ICSoIF/DwH0YpmT4kffrqEzpadlKCw==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-1.42.1.tgz",
+      "integrity": "sha512-h/ZzXz03EbxYIkTtZ4+MciWJjejz2xFp7m6FIi/GXHTmDdj3tLucUxWMExieCMpCzGD9qWP2wXb3T0wLvoF0Fw==",
       "requires": {
         "archiver": "^1.1.0",
         "async": "^1.5.2",
-        "aws-sdk": "^2.373.0",
+        "aws-sdk": "^2.430.0",
         "bluebird": "^3.5.0",
+        "cachedir": "^2.2.0",
         "chalk": "^2.0.0",
         "ci-info": "^1.1.1",
         "download": "^5.0.2",
@@ -3933,12 +3992,14 @@
         "graceful-fs": "^4.1.11",
         "https-proxy-agent": "^2.2.1",
         "is-docker": "^1.1.0",
-        "js-yaml": "^3.6.1",
+        "js-yaml": "^3.13.0",
         "json-cycle": "^1.3.0",
         "json-refs": "^2.1.5",
+        "jszip": "^3.2.1",
         "jwt-decode": "^2.2.0",
         "lodash": "^4.13.1",
         "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
         "moment": "^2.13.0",
         "nanomatch": "^1.2.13",
         "node-fetch": "^1.6.0",
@@ -3947,7 +4008,7 @@
         "raven": "^1.2.1",
         "rc": "^1.1.6",
         "replaceall": "^0.1.6",
-        "semver": "^5.0.3",
+        "semver": "^5.7.0",
         "semver-regex": "^1.0.0",
         "tabtab": "^2.2.2",
         "untildify": "^3.0.3",
@@ -3955,6 +4016,60 @@
         "uuid": "^2.0.2",
         "write-file-atomic": "^2.1.0",
         "yaml-ast-parser": "0.0.34"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.452.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.452.0.tgz",
+          "integrity": "sha512-l6J2NmUg12xpDKG9YdlPje5+Z+nNvqyWMA85ookzPqwx8RcD28D3vg4K1aGi27/oo/3NsngR3XfKUBPSqUpUMA==",
+          "requires": {
+            "buffer": "4.9.1",
+            "events": "1.1.1",
+            "ieee754": "1.1.8",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.3.2",
+            "xml2js": "0.4.19"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "serverless-http": {
@@ -3966,6 +4081,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.0",
@@ -4581,29 +4701,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "unbzip2-stream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.2.tgz",
-      "integrity": "sha512-l71qM60cLs5GjR4uJsACOADWuttjtGNLcQdOj6FxSkxhovPiX2+pm+mERrYjkYqAx9EZoQh3LD61oSYx0tycww==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-        },
-        "buffer": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-          "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-          "requires": {
-            "base64-js": "0.0.8",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        }
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "union-value": {
@@ -4904,6 +5007,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3864,6 +3864,11 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -4011,6 +4016,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.10.0",
@@ -5139,6 +5149,15 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "contentful-management": "^5.7.0",
     "express": "^4.16.4",
     "helmet": "^3.15.1",
+    "json-cycle": "^1.3.0",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",
     "patreon": "^0.4.1",
@@ -27,6 +28,7 @@
     "rss-parser": "^3.7.0",
     "serverless": "^1.42.1",
     "serverless-http": "^1.9.0",
+    "striptags": "^3.1.1",
     "yargs": "^13.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "serverless": "^1.42.1",
     "serverless-http": "^1.9.0",
     "striptags": "^3.1.1",
+    "url-parse": "^1.4.7",
     "uuid": "^3.3.2",
     "yargs": "^13.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "patreon": "^0.4.1",
     "progress": "^2.0.3",
     "qs": "^6.6.0",
+    "rss": "^1.2.2",
     "rss-parser": "^3.7.0",
-    "serverless": "^1.36.3",
+    "serverless": "^1.42.1",
     "serverless-http": "^1.9.0",
     "yargs": "^13.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -10,16 +10,20 @@
     "auth-sls": "assume-role theliturgists-deploy serverless"
   },
   "dependencies": {
+    "@hapi/joi": "^15.0.3",
     "@sentry/node": "^4.6.4",
     "aws-param-store": "^2.1.0",
     "aws-sdk": "^2.399.0",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "contentful-management": "^5.7.0",
+    "dynamodb": "^1.2.0",
     "express": "^4.16.4",
     "helmet": "^3.15.1",
     "json-cycle": "^1.3.0",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
+    "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "patreon": "^0.4.1",
     "progress": "^2.0.3",
@@ -29,6 +33,7 @@
     "serverless": "^1.42.1",
     "serverless-http": "^1.9.0",
     "striptags": "^3.1.1",
+    "uuid": "^3.3.2",
     "yargs": "^13.2.2"
   },
   "devDependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,8 @@ provider:
   runtime: nodejs8.10
   stage: dev
   region: us-east-1
+  tracing:
+    lambda: true
   environment:
     SLS_STAGE: ${self:custom.stage}
   iamRoleStatements:
@@ -32,6 +34,7 @@ functions:
       - http: GET /patreon/authorize
       - http: POST /patreon/validate
       - http: GET /contentful/{proxy+}
+      - http: GET /rss/{proxy+}
   sync:
     handler: src/sync.handler
     timeout: 300

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: theliturgists-backend-${self:custom.namespace}
+service: ${self:custom.service}-${self:custom.namespace}
 
 provider:
   name: aws
@@ -9,6 +9,7 @@ provider:
     lambda: true
   environment:
     SLS_STAGE: ${self:custom.stage}
+    DYNAMODB_TABLE_TOKENS: ${self:custom.dynamodbTables.tokens}
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -25,6 +26,36 @@ provider:
             - Ref: AWS::Region
             - Ref: AWS::AccountId
             - "parameter/${self:custom.stage}/*"
+    - Effect: Allow
+      Action:
+        - dynamodb:DescribeTable
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:UpdateItem
+        - dynamodb:DeleteItem
+      Resource:
+        - "Fn::GetAtt": [ TokensDynamoDBTable, Arn ]
+        - Fn::Join:
+            - "/"
+            - - "Fn::GetAtt": [ TokensDynamoDBTable, Arn ]
+              - "index"
+              - "*"
+
+  stackPolicy:
+    - Effect: Allow
+      Action: "Update:*"
+      Principal: "*"
+      Resource: "*"
+    - Effect: "Deny"
+      Action: ["Update:Replace"]
+      Principal: "*"
+      Resource: "LogicalResourceId/TokensDynamoDBTable"
+    - Effect: "Deny"
+      Action: ["Update:Delete"]
+      Principal: "*"
+      Resource: "LogicalResourceId/TokensDynamoDBTable"
 
 functions:
   app:
@@ -33,6 +64,7 @@ functions:
     events:
       - http: GET /patreon/authorize
       - http: POST /patreon/validate
+      - http: GET /patreon/api/{proxy+}
       - http: GET /contentful/{proxy+}
       - http: GET /rss/{proxy+}
   sync:
@@ -44,8 +76,35 @@ functions:
           enabled: ${self:custom.syncEnabled.${self:custom.stage}}
 
 custom:
+  service: theliturgists-backend
   namespace: ${env:SLS_NAMESPACE, env:USER}
   stage: ${opt:stage, self:provider.stage}
   syncEnabled:
     dev: false
     staging: true
+  dynamodbTables:
+    tokens: "${self:custom.service}-${self:custom.namespace}-${self:custom.stage}-tokens"
+
+resources:
+  Resources:
+    TokensDynamoDBTable:
+      # Table to store user id / Patreon id/token mapping
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.dynamodbTables.tokens}
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: patreonUserId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: patreonUserIdIndex
+            KeySchema:
+              - AttributeName: patreonUserId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+        BillingMode: PAY_PER_REQUEST

--- a/src/TokenMapping.js
+++ b/src/TokenMapping.js
@@ -1,0 +1,30 @@
+const dynamodb = require('dynamodb');
+const Joi = require('@hapi/joi');
+
+const TokenMapping = dynamodb.define(
+  'TokenMapping',
+  {
+    hashKey: 'userId',
+    timestamps: true,
+    schema: {
+      userId: Joi.string(),
+      patreonUserId: Joi.string(),
+      patreonToken: Joi.string(),
+      refreshToken: Joi.string(),
+      expiresAt: Joi.string(),
+    },
+    indexes: [
+      {
+        hashKey: 'patreonUserId',
+        type: 'global',
+        name: 'patreonUserIdIndex',
+      },
+    ],
+  },
+);
+
+TokenMapping.config({
+  tableName: process.env.DYNAMODB_TABLE_TOKENS,
+});
+
+module.exports = TokenMapping;

--- a/src/creds.js
+++ b/src/creds.js
@@ -20,6 +20,9 @@ const credSpecs = {
   sentry: {
     dsn: `/${stage}/SENTRY_DSN`,
   },
+  jwt: {
+    secret: `/${stage}/JWT_SECRET`,
+  },
 };
 
 module.exports.getCreds = async (name) => {


### PR DESCRIPTION
- Store Patreon tokens in DynamoDB, indexed by generated user ID
- On Patreon OAuth, return a token
  - Side effect: a user can connect Patreon in the app on multiple devices at once
- Filter feed access using Patreon level
- Dynamically generate a feed per collection (podcasts, meditation categories)
- Generate RSS that approximates the metadata included in Patreon RSS feeds

Tested resulting RSS in these iOS apps:
- [x] Podcasts (built-in)
- [x] Overcast
- [ ] Castro
  -  "Invalid feed" error. Possibly SSL-related; haven't heard back from Castro support yet.
  - Merging this PR without resolving this issue; will open a bug to track it
- [x] Castbox

Paid apps (not tested, but perhaps should later):
- Pocket Casts
- Downcast

Closes #6.