### PR TITLE
Use patreon-pledge module for access control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,15 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
+      "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@contentful/axios": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@contentful/axios/-/axios-0.18.0.tgz",
@@ -576,6 +585,15 @@
         "form-urlencoded": "^2.0.4",
         "is-plain-object": "^2.0.4",
         "isomorphic-fetch": "^2.2.1"
+      }
+    },
+    "@theliturgists/patreon-pledge": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@theliturgists/patreon-pledge/-/patreon-pledge-0.1.1.tgz",
+      "integrity": "sha512-5U9czyK4/Uq89e9ukMacUUTz7MoiT65ZDJ2w1oWX6vjhqbueT5mkvtC6wzSiueVo6kg/+p+2qS6y23QOi7llsA==",
+      "requires": {
+        "@babel/polyfill": "^7.8.3",
+        "@theliturgists/jsonapi-datastore": "^0.4.0-beta-3"
       }
     },
     "@types/caseless": {
@@ -1597,6 +1615,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5042,6 +5065,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
       "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@hapi/joi": "^15.0.3",
     "@sentry/node": "^5.12.0",
     "@theliturgists/patreon": "^0.4.1-2",
+    "@theliturgists/patreon-pledge": "^0.1.1",
     "aws-param-store": "^2.1.0",
     "aws-sdk": "^2.399.0",
     "axios": "^0.18.1",


### PR DESCRIPTION
This was pretty simple now that the patreon-pledge package has been extracted; I just replaced the duplicated logic here with calls to that module. Minor tweaks were required to handle the re-validation case, as well as to get the raw Patreon API JSON instead of a JsonApiDataStore object.

Note: the podcast field change from `minimumPledgeDollars` to `patreonsOnly` was accompanied by an upstream content type change in Contentful. This was done because we already didn't support podcasts with different minimum pledge levels, and the introduction of the new tiers still kept the same pledge required for patron podcast access. We could perhaps make this more general in the future, but for now, what we have is sufficient, so we've made it explicit in Contentful.

Note further that the `patreonsOnly` field on a podcast is set in Contentful and denotes that only patrons should have access to its episodes. In contrast, there is a `patronsOnly` field that the backend itself adds to every media entry, which is set based on whether the backend has determined that the requesting user should or should not have access based on their Patreon pledge (or lack thereof).

Closes #19.