### PR TITLE
Scoped notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1853,10 +1853,53 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
+      }
+    },
     "dom-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
     },
     "dont-sniff-mimetype": {
       "version": "1.1.0",
@@ -3329,6 +3372,11 @@
         }
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "helmet": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.21.2.tgz",
@@ -3402,6 +3450,47 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+    },
+    "html-to-text": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
+      "integrity": "sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==",
+      "requires": {
+        "he": "^1.2.0",
+        "htmlparser2": "^3.10.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -3648,6 +3737,14 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-html/-/is-html-2.0.0.tgz",
+      "integrity": "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==",
+      "requires": {
+        "html-tags": "^3.0.0"
       }
     },
     "is-installed-globally": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "express": "^4.16.4",
     "firebase-admin": "^8.2.0",
     "helmet": "^3.21.2",
+    "html-to-text": "^5.1.1",
+    "is-html": "^2.0.0",
     "json-cycle": "^1.3.0",
     "lodash": "^4.17.13",
     "moment": "^2.24.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ provider:
   tracing:
     lambda: true
   environment:
+    SLS_NAMESPACE: ${self:custom.namespace}
     SLS_STAGE: ${self:custom.stage}
     DYNAMODB_TABLE_TOKENS: ${self:custom.dynamodbTables.tokens}
   iamRoleStatements:

--- a/src/notify.js
+++ b/src/notify.js
@@ -20,7 +20,7 @@ const TOPIC_PATRON_PODCAST = 'new-patron-podcast';
 const TOPIC_PATRON_MEDITATION = 'new-patron-meditation';
 const TOPIC_PATRON_LITURGY = 'new-patron-liturgy';
 
-function getTopic(entry, collectionEntry) {
+function getUnscopedTopic(entry, collectionEntry) {
   if (_.get(entry, 'fields.isFreePreview.en-US')) {
     return TOPIC_PUBLIC_MEDIA;
   }
@@ -36,6 +36,20 @@ function getTopic(entry, collectionEntry) {
     return collectionEntry.fields.minimumPledgeDollars ? TOPIC_PATRON_PODCAST : TOPIC_PUBLIC_MEDIA;
   }
   return TOPIC_PUBLIC_MEDIA;
+}
+
+function getTopic(entry, collectionEntry) {
+  const topic = getUnscopedTopic(entry, collectionEntry);
+  const namespace = process.env.SLS_NAMESPACE;
+  const stage = process.env.SLS_STAGE;
+  let scope;
+  if (namespace === stage) {
+    // avoid unnecessary length of "staging-staging"
+    scope = stage;
+  } else {
+    scope = `${namespace}-${stage}`;
+  }
+  return `${topic}-${scope}`;
 }
 
 function getImageUrl(collectionEntry) {

--- a/src/notify.js
+++ b/src/notify.js
@@ -72,20 +72,27 @@ function stripTags(html) {
   return html.replace(/<[^>]+>/g, '');
 }
 
-function formatDescription(description) {
-  return truncate(stripTags(description));
+function formatSubtitle(collectionEntry) {
+  // collection is only missing for uncategorized meditations
+  const title = _.get(collectionEntry, 'fields.title', 'Uncategorized');
+
+  if (collectionEntry.sys.contentType.sys.id === 'meditationCategory') {
+    return `Meditation: ${title}`;
+  }
+  return title;
 }
 
 function makeNotification(entry, collectionEntry) {
   const topic = getTopic(entry, collectionEntry);
   const title = entry.fields.title['en-US'];
-  const subtitle = collectionEntry.fields.title;
+  const subtitle = formatSubtitle(collectionEntry);
+  const description = formatDescription(entry.fields.description['en-US']);
 
   return {
     topic,
     notification: {
-      title: `${title} (${subtitle})`,
-      body: formatDescription(entry.fields.description['en-US']),
+      title,
+      body: `${subtitle}\n\n${description}`,
     },
     android: {
       notification: {

--- a/src/notify.js
+++ b/src/notify.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const firebase = require('firebase-admin');
+const isHtml = require('is-html');
+const htmlToText = require('html-to-text');
 
 const { getCreds } = require('./creds');
 
@@ -68,8 +70,12 @@ function truncate(str, limit = 1024) {
   return str.slice(0, limit - 3) + '...';
 }
 
-function stripTags(html) {
-  return html.replace(/<[^>]+>/g, '');
+function formatDescription(description) {
+  let text = description;
+  if (isHtml(description)) {
+    text = htmlToText.fromString(description);
+  }
+  return truncate(text);
 }
 
 function formatSubtitle(collectionEntry) {


### PR DESCRIPTION
## Description

First, this PR adds a "scope" to the notification topics, for the purpose of testing. This way, using records in the `sandbox` environment of our Contentful space, we can test changes to push notifications without actually notifying real users. The app subscribes to the scoped topic depending on whether it's a dev build or a staging build.

Second, this PR tweaks the format of notifications in a couple ways:
- If the item description contains HTML, render it to text rather than stripping it.
  - This preserves things like the line spacing intended by `<p>...</p>` tags.
- Rather than appending the collection title (e.g. podcast name) to the title, put it at the top of the description.
  - This ensures that the collection title is always visible, no matter how long the item title is.

## Screenshots

Though this is a backend PR, it affects how notifications appear in the app, so I'm putting the screenshots here.

### iOS
| Collapsed | Expanded |
| ---- | ---- |
| ![iOS, collapsed](https://user-images.githubusercontent.com/91550/77133659-423a8400-6a3a-11ea-81ae-7bcc1ebcfdc0.PNG) | ![iOS, expanded](https://user-images.githubusercontent.com/91550/77133693-6007e900-6a3a-11ea-9be5-5b7fad846676.PNG) |

### Android
| Collapsed | Expanded |
| ---- | ---- |
| <img width="508" alt="Screen Shot 2020-03-19 at 11 35 34 PM" src="https://user-images.githubusercontent.com/91550/77133749-95143b80-6a3a-11ea-8729-bd335a8ad223.png"> | <img width="508" alt="Screen Shot 2020-03-19 at 11 24 39 PM" src="https://user-images.githubusercontent.com/91550/77133636-246d1f00-6a3a-11ea-958f-a06886bed727.png"> |